### PR TITLE
Fix error with code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,4 @@ jobs:
         with:
           coverageLocations: |
             ${{github.workspace}}/coverage.info:lcov
+          prefix: ${{github.workspace}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
         run: |
           dotnet coverlet ./exe --target "ruby" --targetargs 'bin/test.rb --skip-build' --format lcov
 
+      - name: "[Test] - Upload coverage as build artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.info
+
       - name: "[Test] - Send Code Coverage Data to Code Climate"
         uses: paambaati/codeclimate-action@v5.0.0
         if: ${{ github.actor != 'dependabot[bot]' && runner.os != 'Windows' }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Maintainability](https://api.codeclimate.com/v1/badges/484b4749424297461774/maintainability)](https://codeclimate.com/github/corgibytes/freshli-agent-dotnet/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/484b4749424297461774/test_coverage)](https://codeclimate.com/github/corgibytes/freshli-agent-dotnet/test_coverage)
+
 # Freshli Agent: DotNet
 
 This application is used by the [`freshli` CLI](https://github.com/corgibytes/freshli-cli) to detect and process manifest files from the DotNet (.NET) ecosystem.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Maintainability](https://api.codeclimate.com/v1/badges/484b4749424297461774/maintainability)](https://codeclimate.com/github/corgibytes/freshli-agent-dotnet/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/484b4749424297461774/test_coverage)](https://codeclimate.com/github/corgibytes/freshli-agent-dotnet/test_coverage)
-
 # Freshli Agent: DotNet
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/484b4749424297461774/maintainability)](https://codeclimate.com/github/corgibytes/freshli-agent-dotnet/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/484b4749424297461774/test_coverage)](https://codeclimate.com/github/corgibytes/freshli-agent-dotnet/test_coverage)
 
 This application is used by the [`freshli` CLI](https://github.com/corgibytes/freshli-cli) to detect and process manifest files from the DotNet (.NET) ecosystem.
 


### PR DESCRIPTION
The CodeClimate coverage reports are being rejected with the error `"Invalid path part \"/\""`.