### PR TITLE
Fixes issues with incomplete release history

### DIFF
--- a/Corgibytes.Freshli.Agent.DotNet.Test/Corgibytes.Freshli.Agent.DotNet.Test.csproj
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Corgibytes.Freshli.Agent.DotNet.Test.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="Moq" Version="4.18.0" />
         <PackageReference Include="xunit" Version="2.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Corgibytes.Freshli.Agent.DotNet.Test/Lib/ManifestProcessorTest.cs
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Lib/ManifestProcessorTest.cs
@@ -10,19 +10,19 @@ public class ManifestProcessorTest
     private readonly ManifestProcessor _manifestProcessor = new();
 
     [Fact]
-    public void ProcessProjectManifest()
+    public async Task ProcessProjectManifest()
     {
         var path = Fixtures.Path("csproj", "Project.csproj");
         var projectFile = new DirectoryInfo(path);
         var analysisPath = projectFile.FullName;
-        var bomFilePath = _manifestProcessor.ProcessManifest(analysisPath, DateTimeOffset.Parse("2023-09-06T00:00:00.0000000Z"));
+        var bomFilePath = await _manifestProcessor.ProcessManifest(analysisPath, DateTimeOffset.Parse("2023-09-06T00:00:00.0000000Z"));
         Assert.NotEmpty(bomFilePath);
 
         var expectedBomFilePath = projectFile.Parent!.FullName + "/obj/bom.json";
         Assert.Equal(expectedBomFilePath, bomFilePath);
         Assert.True(File.Exists(bomFilePath));
         var json =
-            JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(File.ReadAllText(bomFilePath));
+            JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(await File.ReadAllTextAsync(bomFilePath));
         Assert.Equal(7, json?.Count);
         var components = json!["components"];
         Assert.Equal(79, components.GetArrayLength());
@@ -30,20 +30,20 @@ public class ManifestProcessorTest
     }
 
     [Fact]
-    public void ProcessPackagesManifest()
+    public async Task ProcessPackagesManifest()
     {
         var path = Fixtures.Path("config", "packages.config");
 
         var projectFile = new DirectoryInfo(path);
         var analysisPath = projectFile.FullName;
-        var bomFilePath = _manifestProcessor.ProcessManifest(analysisPath, DateTimeOffset.Parse("2023-09-05T00:00:00.0000000Z"));
+        var bomFilePath = await _manifestProcessor.ProcessManifest(analysisPath, DateTimeOffset.Parse("2023-09-05T00:00:00.0000000Z"));
         Assert.NotEmpty(bomFilePath);
 
         var expectedBomFilePath = projectFile.Parent!.FullName + "/obj/bom.json";
         Assert.Equal(expectedBomFilePath, bomFilePath);
         Assert.True(File.Exists(bomFilePath));
         var json =
-            JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(File.ReadAllText(bomFilePath));
+            JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(await File.ReadAllTextAsync(bomFilePath));
         Assert.Equal(7, json?.Count);
         var components = json!["components"];
         Assert.Equal(4, components.GetArrayLength());
@@ -51,16 +51,16 @@ public class ManifestProcessorTest
     }
 
     [Fact]
-    public void ProcessOpserverManifest()
+    public async Task ProcessOpserverManifest()
     {
         // This manifest file results in an error, because one of the packages is no longer
-        // listed. The CylcloneDX DotNet tool attempts to run NuGet restore on the manifest
+        // listed. The CycloneDX DotNet tool attempts to run NuGet restore on the manifest
         // file, and that process fails when the package is unlisted.
         var path = Fixtures.Path("config", "Opserver.Core", "packages.config");
         var asOfDate = DateTimeOffset.Parse("2015-05-01T00:00:00.0000Z");
-        Assert.Throws<ManifestProcessingException>(() =>
+        await Assert.ThrowsAsync<ManifestProcessingException>(async () =>
         {
-            _manifestProcessor.ProcessManifest(path, asOfDate);
+            await _manifestProcessor.ProcessManifest(path, asOfDate);
         });
     }
 }

--- a/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/NuGetVersionInfoTest.cs
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/NuGetVersionInfoTest.cs
@@ -1,9 +1,9 @@
 using Corgibytes.Freshli.Agent.DotNet.Lib.NuGet;
+using Moq;
+using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Xunit;
-using Moq;
-using NuGet.Packaging.Core;
 
 namespace Corgibytes.Freshli.Agent.DotNet.Test.Lib.NuGet;
 

--- a/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/NuGetVersionInfoTest.cs
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/NuGetVersionInfoTest.cs
@@ -93,6 +93,15 @@ public class NuGetVersionInfoTest
     }
 
     [Fact]
+    public void VersionStripsMetadata()
+    {
+        const string version = "5.0.0+42a8779499c1d1ed2488c2e6b9e2ee6ff6107766";
+        var versionInfo = BuildNuGetVersionInfoFrom(version);
+
+        Assert.Equal("5.0.0", versionInfo.Version);
+    }
+
+    [Fact]
     public void ThrowsExceptionIfNull()
     {
         Assert.Throws<ArgumentException>(() =>

--- a/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/NuGetVersionInfoTest.cs
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/NuGetVersionInfoTest.cs
@@ -1,11 +1,54 @@
 using Corgibytes.Freshli.Agent.DotNet.Lib.NuGet;
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Xunit;
+using Moq;
+using NuGet.Packaging.Core;
 
 namespace Corgibytes.Freshli.Agent.DotNet.Test.Lib.NuGet;
 
 public class NuGetVersionInfoTest
 {
+    private static IPackageSearchMetadata BuildMockPackageSearchMetadata(string version, DateTimeOffset releaseDate)
+    {
+        var mockPackageSearchMetadata = new Mock<IPackageSearchMetadata>();
+        var packageIdentity = new PackageIdentity("MockPackage", new NuGetVersion(version));
+        mockPackageSearchMetadata.Setup(mock => mock.Identity).Returns(packageIdentity);
+        mockPackageSearchMetadata.Setup(mock => mock.IsListed).Returns(true);
+        mockPackageSearchMetadata.Setup(mock => mock.Published).Returns(releaseDate);
+        return mockPackageSearchMetadata.Object;
+    }
+
+    private static DateTimeOffset UnlistedPackagePublishedDate => DateTimeOffset.Parse("1900-01-01T00:00:00Z");
+
+    private static IPackageSearchMetadata BuildMockUnlistedPackageSearchMetadata(string version)
+    {
+        var mockPackageSearchMetadata = new Mock<IPackageSearchMetadata>();
+        var packageIdentity = new PackageIdentity("MockUnlistedPackage", new NuGetVersion(version));
+        mockPackageSearchMetadata.Setup(mock => mock.Identity).Returns(packageIdentity);
+        mockPackageSearchMetadata.Setup(mock => mock.IsListed).Returns(false);
+        mockPackageSearchMetadata.Setup(mock => mock.Published).Returns(UnlistedPackagePublishedDate);
+        return mockPackageSearchMetadata.Object;
+    }
+
+    private static NuGetVersionInfo BuildNuGetVersionInfoFrom(string version)
+    {
+        return BuildNuGetVersionInfoFrom(version, DateTimeOffset.UtcNow);
+    }
+
+    private static NuGetVersionInfo BuildNuGetVersionInfoFrom(string version, DateTimeOffset releaseDate)
+    {
+        return BuildNuGetVersionInfoFrom(version, releaseDate, Array.Empty<IPackageSearchMetadata>());
+    }
+
+    private static NuGetVersionInfo BuildNuGetVersionInfoFrom(string version, DateTimeOffset releaseDate, IEnumerable<IPackageSearchMetadata> releasesMetadata)
+    {
+        return new NuGetVersionInfo(
+            BuildMockPackageSearchMetadata(version, releaseDate),
+            releasesMetadata
+        );
+    }
+
     [Theory]
     [InlineData("1", "2", -1)]
     [InlineData("1", "1", 0)]
@@ -18,17 +61,13 @@ public class NuGetVersionInfoTest
     public void CompareToCorrectlySortsByVersion(
         string version1,
         string version2,
-        int result
+        int expected
     )
     {
-        var versionInfo1 = new NuGetVersionInfo(
-            new NuGetVersion(version1), DateTimeOffset.UtcNow
-        );
-        var versionInfo2 = new NuGetVersionInfo(
-            new NuGetVersion(version2), DateTimeOffset.UtcNow
-        );
+        var versionInfo1 = BuildNuGetVersionInfoFrom(version1);
+        var versionInfo2 = BuildNuGetVersionInfoFrom(version2);
 
-        Assert.Equal(versionInfo1.CompareTo(versionInfo2), result);
+        Assert.Equal(expected, versionInfo1.CompareTo(versionInfo2));
     }
 
     [Theory]
@@ -36,45 +75,132 @@ public class NuGetVersionInfoTest
     [InlineData("1.0.0", false)]
     public void IdentifiesPreRelease(
         string version,
-        bool result
+        bool expected
     )
     {
-        var versionInfo = new NuGetVersionInfo(
-            new NuGetVersion(version), DateTimeOffset.UtcNow
-        );
+        var versionInfo = BuildNuGetVersionInfoFrom(version);
 
-        Assert.Equal(versionInfo.IsPreRelease, result);
+        Assert.Equal(expected, versionInfo.IsPreRelease);
     }
 
     [Fact]
     public void ProvidesVersion()
     {
-        var version = "1.0.0";
-        var versionInfo = new NuGetVersionInfo(
-            new NuGetVersion(version), DateTimeOffset.UtcNow
-        );
+        const string version = "1.0.0";
+        var versionInfo = BuildNuGetVersionInfoFrom(version);
 
-        Assert.Equal(versionInfo.Version, version);
+        Assert.Equal(version, versionInfo.Version);
     }
 
     [Fact]
     public void ThrowsExceptionIfNull()
     {
-        Assert.Throws<ArgumentException>
-        (() => new NuGetVersionInfo(
-            new NuGetVersion("1.0.0"),
-            DateTimeOffset.UtcNow).CompareTo(null));
+        Assert.Throws<ArgumentException>(() =>
+            BuildNuGetVersionInfoFrom(null!)
+        );
     }
 
     [Fact]
     public void ThrowsExceptionIfNonMatchingType()
     {
-        Assert.Throws<ArgumentException>
-        (() => new NuGetVersionInfo(
-                new NuGetVersion("1.0.0"),
-                DateTimeOffset.UtcNow).CompareTo(
-                new NuGetVersion("1.0.0")
-            )
+        Assert.Throws<ArgumentException>(() =>
+            BuildNuGetVersionInfoFrom("1.0.0").CompareTo(new object())
         );
     }
+
+    [Theory]
+    [MemberData(nameof(DatePublishedData))]
+    public void DatePublished(string _, IPackageSearchMetadata versionMetadata, IList<IPackageSearchMetadata> releasesMetadata, DateTimeOffset expectedReleaseDate)
+    {
+        var versionInfo = new NuGetVersionInfo(versionMetadata, releasesMetadata);
+
+        Assert.Equal(expectedReleaseDate, versionInfo.DatePublished);
+    }
+
+    public static IEnumerable<object[]> DatePublishedData() =>
+        new List<object[]>
+        {
+            new object[]
+            {
+                "Listed Package",
+                BuildMockPackageSearchMetadata("1.0.0", DateTimeOffset.Parse("2021-01-01T00:00:00Z")),
+                Array.Empty<IPackageSearchMetadata>(),
+                DateTimeOffset.Parse("2021-01-01T00:00:00Z")
+            },
+
+            new object[]
+            {
+                "Unlisted package, empty release history",
+                BuildMockUnlistedPackageSearchMetadata("1.0.0"),
+                Array.Empty<IPackageSearchMetadata>(),
+                UnlistedPackagePublishedDate
+            },
+
+            new object[]
+            {
+                "Unlisted package, only unlisted releases",
+                BuildMockUnlistedPackageSearchMetadata("1.0.1"),
+                new[]
+                {
+                    BuildMockUnlistedPackageSearchMetadata("1.0.0"),
+                    BuildMockUnlistedPackageSearchMetadata("1.0.1"),
+                    BuildMockUnlistedPackageSearchMetadata("1.0.2"),
+                },
+                UnlistedPackagePublishedDate
+            },
+
+            new object[]
+            {
+                "Unlisted package as first release",
+                BuildMockUnlistedPackageSearchMetadata("1.0.0"),
+                new[]
+                {
+                    BuildMockUnlistedPackageSearchMetadata("1.0.0"),
+                    BuildMockPackageSearchMetadata("1.0.1", DateTimeOffset.Parse("2022-01-01T00:00:00Z")),
+                },
+                DateTimeOffset.Parse("2022-01-01T00:00:00Z")
+            },
+
+            new object[]
+            {
+                "Unlisted package as last release",
+                BuildMockUnlistedPackageSearchMetadata("1.0.1"),
+                new[]
+                {
+                    BuildMockPackageSearchMetadata("1.0.0", DateTimeOffset.Parse("2022-01-01T00:00:00Z")),
+                    BuildMockUnlistedPackageSearchMetadata("1.0.1"),
+                },
+                DateTimeOffset.Parse("2022-01-01T00:00:00Z")
+            },
+
+            new object[]
+            {
+                "Unlisted package as middle release",
+                BuildMockUnlistedPackageSearchMetadata("1.0.1"),
+                new[]
+                {
+                    BuildMockPackageSearchMetadata("1.0.0", DateTimeOffset.Parse("2022-01-01T00:00:00Z")),
+                    BuildMockUnlistedPackageSearchMetadata("1.0.1"),
+                    BuildMockPackageSearchMetadata("1.0.2", DateTimeOffset.Parse("2022-01-02T00:00:00Z")),
+                },
+                DateTimeOffset.Parse("2022-01-01T12:00:00Z")
+            },
+
+            new object[]
+            {
+                "Unlisted package as middle release and between unlisted packages",
+                BuildMockUnlistedPackageSearchMetadata("1.0.2"),
+                new[]
+                {
+                    BuildMockPackageSearchMetadata("1.0.0", DateTimeOffset.Parse("2022-01-01T00:00:00Z")),
+                    BuildMockUnlistedPackageSearchMetadata("1.0.1"),
+                    BuildMockUnlistedPackageSearchMetadata("1.0.2"),
+                    BuildMockUnlistedPackageSearchMetadata("1.0.3"),
+                    BuildMockPackageSearchMetadata("1.0.4", DateTimeOffset.Parse("2022-01-02T00:00:00Z")),
+                },
+                DateTimeOffset.Parse("2022-01-01T12:00:00Z")
+            },
+
+
+        };
 }

--- a/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/VersionsTest.cs
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/VersionsTest.cs
@@ -36,15 +36,15 @@ public class VersionsTest
 
     [Theory]
     [MemberData(nameof(UpdatePackagesManifestArgs))]
-    public void UpdatePackagesManifest(string[] manifestFixturePath, string date)
+    public async Task UpdatePackagesManifest(string[] manifestFixturePath, string date)
     {
         var manifestFilePath = Fixtures.Path(manifestFixturePath);
-        var expectedHash = Hash(File.ReadAllText(manifestFilePath));
+        var expectedHash = Hash(await File.ReadAllTextAsync(manifestFilePath));
 
-        Versions.UpdateManifest(manifestFilePath, DateTimeOffset.Parse(date));
+        await Versions.UpdateManifest(manifestFilePath, DateTimeOffset.Parse(date));
         try
         {
-            var actualHash = Hash(File.ReadAllText(manifestFilePath));
+            var actualHash = Hash(await File.ReadAllTextAsync(manifestFilePath));
             Assert.Equal(expectedHash, actualHash);
         }
         finally

--- a/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/VersionsTest.cs
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Lib/NuGet/VersionsTest.cs
@@ -10,10 +10,10 @@ public class VersionsTest
 {
     [Theory]
     [MemberData(nameof(UpdateNuGetManifestArgs))]
-    public void UpdateNuGetManifest(string[] manifestFixturePath, string date, PackageInfo[] expectedUpdates)
+    public async Task UpdateNuGetManifest(string[] manifestFixturePath, string date, PackageInfo[] expectedUpdates)
     {
         var manifestFilePath = Fixtures.Path(manifestFixturePath);
-        Versions.UpdateManifest(manifestFilePath, DateTimeOffset.Parse(date));
+        await Versions.UpdateManifest(manifestFilePath, DateTimeOffset.Parse(date));
         try
         {
             var manifest = new NuGetManifest(manifestFilePath);

--- a/Corgibytes.Freshli.Agent.DotNet.Test/Lib/ReleaseHistoryRetrieverTest.cs
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Lib/ReleaseHistoryRetrieverTest.cs
@@ -111,7 +111,7 @@ public class ReleaseHistoryRetrieverTest
 
         var releaseDatesByVersion = new Dictionary<string, DateTimeOffset>
         {
-            { "5.11.0", DateTimeOffset.Parse("1900-01-01T00:00:00.0000000+00:00") },// DateTimeOffset.Parse("2021-08-12T23:42:43.8430000+00:00") },
+            { "5.11.0", DateTimeOffset.Parse("2022-02-12T05:39:14.7850000+00:00") },
             { "6.7.0", DateTimeOffset.Parse("2023-08-09T20:56:19.7100000+00:00") },
         };
 

--- a/Corgibytes.Freshli.Agent.DotNet.Test/Lib/ReleaseHistoryRetrieverTest.cs
+++ b/Corgibytes.Freshli.Agent.DotNet.Test/Lib/ReleaseHistoryRetrieverTest.cs
@@ -1,4 +1,5 @@
 using Corgibytes.Freshli.Agent.DotNet.Lib;
+using FluentAssertions;
 using Xunit;
 
 namespace Corgibytes.Freshli.Agent.DotNet.Test.Lib;
@@ -6,9 +7,10 @@ namespace Corgibytes.Freshli.Agent.DotNet.Test.Lib;
 public class ReleaseHistoryRetrieverTest
 {
     [Fact]
-    public void Retrieve()
+    public async Task Retrieve()
     {
-        var packageReleases = new ReleaseHistoryRetriever()
+        var releaseRetriever = new ReleaseHistoryRetriever();
+        var packageReleases = await releaseRetriever
             .Retrieve("pkg:nuget/Corgibytes.Freshli.Lib@0.5.0");
 
         var releaseDatesByVersion = new Dictionary<string, DateTimeOffset>
@@ -62,6 +64,61 @@ public class ReleaseHistoryRetrieverTest
                     value.ReleasedAt == expectedDate
                 )
             );
+        }
+    }
+
+    [Fact]
+    public async Task MicrosoftEntityFrameworkCoreSqliteCore()
+    {
+        var releaseRetriever = new ReleaseHistoryRetriever();
+        var packageReleases = await releaseRetriever
+            .Retrieve("pkg:nuget/Microsoft.EntityFrameworkCore.Sqlite.Core");
+
+        var releaseDatesByVersion = new Dictionary<string, DateTimeOffset>
+        {
+            { "7.0.11", DateTimeOffset.Parse("2023-09-12T13:11:11.2830000+00:00") },
+            { "7.0.10", DateTimeOffset.Parse("2023-08-08T12:15:55.3200000+00:00") },
+            { "7.0.9", DateTimeOffset.Parse("2023-07-11T13:14:08.0500000+00:00") },
+            { "7.0.8", DateTimeOffset.Parse("2023-06-22T18:04:34.7530000+00:00") },
+            { "7.0.7", DateTimeOffset.Parse("2023-06-13T12:59:12.9000000+00:00") },
+            { "7.0.5", DateTimeOffset.Parse("2023-04-11T13:34:22.2870000+00:00") },
+            { "7.0.4", DateTimeOffset.Parse("2023-03-14T12:28:30.0530000+00:00") },
+            { "7.0.3", DateTimeOffset.Parse("2023-02-14T13:25:17.8400000+00:00") },
+            { "7.0.2", DateTimeOffset.Parse("2023-01-10T14:27:13.7800000+00:00") },
+            { "7.0.1", DateTimeOffset.Parse("2022-12-13T14:26:34.9430000+00:00") },
+            { "7.0.0", DateTimeOffset.Parse("2022-11-07T17:57:26.6200000+00:00") },
+            { "7.0.0-rc.2.22472.11", DateTimeOffset.Parse("2022-10-11T13:27:33.6630000+00:00") },
+        };
+
+        foreach (var (version, expectedDate) in releaseDatesByVersion)
+        {
+            Assert.Equal(
+                1,
+                packageReleases.Count(value =>
+                    value.Version == version &&
+                    value.ReleasedAt == expectedDate
+                )
+            );
+        }
+    }
+
+    [Fact]
+    public async Task IncludesUnlistedVersions()
+    {
+        var releaseRetriever = new ReleaseHistoryRetriever();
+        var packageReleases = await releaseRetriever
+            .Retrieve("pkg:nuget/NuGet.Frameworks@5.11.0");
+
+        var releaseDatesByVersion = new Dictionary<string, DateTimeOffset>
+        {
+            { "5.11.0", DateTimeOffset.Parse("1900-01-01T00:00:00.0000000+00:00") },// DateTimeOffset.Parse("2021-08-12T23:42:43.8430000+00:00") },
+            { "6.7.0", DateTimeOffset.Parse("2023-08-09T20:56:19.7100000+00:00") },
+        };
+
+        foreach (var (version, expectedDate) in releaseDatesByVersion)
+        {
+            packageReleases.Should().Contain(value =>
+                value.Version == version && value.ReleasedAt == expectedDate);
         }
     }
 }

--- a/Corgibytes.Freshli.Agent.DotNet/Corgibytes.Freshli.Agent.DotNet.csproj
+++ b/Corgibytes.Freshli.Agent.DotNet/Corgibytes.Freshli.Agent.DotNet.csproj
@@ -40,6 +40,9 @@
     <Content Include="..\.dockerignore">
       <Link>.dockerignore</Link>
     </Content>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/Corgibytes.Freshli.Agent.DotNet/Lib/ManifestProcessor.cs
+++ b/Corgibytes.Freshli.Agent.DotNet/Lib/ManifestProcessor.cs
@@ -11,7 +11,7 @@ public class ManifestProcessor
 {
     private readonly ILogger<ManifestProcessor> _logger = Logging.Logger<ManifestProcessor>();
 
-    public string ProcessManifest(string manifestFilePath, DateTimeOffset? asOfDate)
+    public async Task<string> ProcessManifest(string manifestFilePath, DateTimeOffset? asOfDate)
     {
         if (!File.Exists(manifestFilePath))
         {
@@ -56,7 +56,7 @@ public class ManifestProcessor
                 Path.Combine(outDir, destFileName));
         }
 
-        var commandResult = Cli.Wrap("dotnet-CycloneDX")
+        var commandResult = await Cli.Wrap("dotnet-CycloneDX")
             .WithArguments(new List<string>
             {
                 manifestFilePath,
@@ -70,9 +70,7 @@ public class ManifestProcessor
             .WithStandardOutputPipe(PipeTarget.ToStream(Console.OpenStandardOutput()))
             .WithValidation(CommandResultValidation.None)
             // TODO: Pass in a cancellation token that will get triggered if Shutdown is called
-            .ExecuteAsync()
-            .Task
-            .Result;
+            .ExecuteAsync();
 
         if (asOfDate != null)
         {

--- a/Corgibytes.Freshli.Agent.DotNet/Lib/ManifestProcessor.cs
+++ b/Corgibytes.Freshli.Agent.DotNet/Lib/ManifestProcessor.cs
@@ -21,7 +21,7 @@ public class ManifestProcessor
         _logger.LogDebug("Processing manifest at {ManifestFilePath} as of {AsOfDate}", manifestFilePath, asOfDate);
         if (asOfDate != null)
         {
-            Versions.UpdateManifest(manifestFilePath, asOfDate.Value);
+            await Versions.UpdateManifest(manifestFilePath, asOfDate.Value);
         }
 
         var manifestDir = new DirectoryInfo(manifestFilePath);

--- a/Corgibytes.Freshli.Agent.DotNet/Lib/NuGet/NuGetVersionInfo.cs
+++ b/Corgibytes.Freshli.Agent.DotNet/Lib/NuGet/NuGetVersionInfo.cs
@@ -1,3 +1,4 @@
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
 namespace Corgibytes.Freshli.Agent.DotNet.Lib.NuGet;
@@ -8,52 +9,93 @@ namespace Corgibytes.Freshli.Agent.DotNet.Lib.NuGet;
     */
 public class NuGetVersionInfo : IVersionInfo
 {
-    private readonly NuGetVersion _nuGetVersion;
-    private int Major => _nuGetVersion.Major;
-    private int Minor => _nuGetVersion.Minor;
-    private int Patch => _nuGetVersion.Patch;
+    private readonly IPackageSearchMetadata _packageSearchMetadata;
+    private readonly IEnumerable<IPackageSearchMetadata> _siblingReleases;
 
-    public DateTimeOffset DatePublished { get; }
-
-    public NuGetVersionInfo(
-        NuGetVersion nuGetVersion,
-        DateTimeOffset datePublished
-    )
+    public NuGetVersionInfo(IPackageSearchMetadata packageSearchMetadata, IEnumerable<IPackageSearchMetadata> siblingReleases)
     {
-        _nuGetVersion = nuGetVersion;
-        DatePublished = datePublished;
+        _packageSearchMetadata = packageSearchMetadata;
+        _siblingReleases = siblingReleases;
     }
 
-    public string Version => _nuGetVersion.ToString();
+    private NuGetVersion NuGetVersion => _packageSearchMetadata.Identity.Version;
 
-    public bool IsPreRelease => _nuGetVersion.IsPrerelease;
+    public string Version =>
+        NuGetVersion.OriginalVersion ??
+        NuGetVersion.ToString();
+
+    public bool IsPreRelease => NuGetVersion.IsPrerelease;
+
+    public DateTimeOffset DatePublished
+    {
+        get
+        {
+            if (_packageSearchMetadata.IsListed)
+            {
+                return _packageSearchMetadata.Published!.Value.UtcDateTime;
+            }
+
+            // TODO: Log a warning that we're approximating the release date of an unlisted version
+            return ApproximateDatePublished();
+        }
+    }
+
+    private DateTimeOffset ApproximateDatePublished()
+    {
+        var listedReleases = _siblingReleases
+            .Where(r => r.IsListed)
+            .ToList();
+
+        var previousRelease = listedReleases
+            .Where(r => r.Identity.Version < NuGetVersion)
+            .MaxBy(r => r.Identity.Version);
+
+        var nextRelease = listedReleases
+            .Where(r => r.Identity.Version > NuGetVersion)
+            .MinBy(r => r.Identity.Version);
+
+        if (previousRelease == null && nextRelease == null)
+        {
+            // there are no listed releases, use the unlisted release date even though it's going to
+            // skew the results
+            // TODO: Log a warning that we were unable to approximate the release date
+            return _packageSearchMetadata.Published!.Value.UtcDateTime;
+        }
+
+        if (previousRelease == null && nextRelease != null)
+        {
+            // the version we're checking is the first version, use the date of the next release
+            return nextRelease.Published!.Value.UtcDateTime;
+        }
+
+        if (nextRelease == null && previousRelease != null)
+        {
+            // the version we're checking is the latest version, use the date of the previous release
+            return previousRelease.Published!.Value.UtcDateTime;
+        }
+
+        // interpolate the date between the previous and next release
+        var previousReleaseDate = previousRelease!.Published!.Value.UtcDateTime;
+        var nextReleaseDate = nextRelease!.Published!.Value.UtcDateTime;
+
+        if (previousReleaseDate > nextReleaseDate)
+        {
+            (nextReleaseDate, previousReleaseDate) = (previousReleaseDate, nextReleaseDate);
+        }
+
+        var span = nextReleaseDate - previousReleaseDate;
+        return previousReleaseDate + (span / 2.0);
+    }
 
     public int CompareTo(object? obj)
     {
         if (obj is not NuGetVersionInfo other)
         {
-            throw new ArgumentException("NuGetVersionInfo not provided " +
-                                        "for CompareTo()");
+            throw new ArgumentException(
+                "NuGetVersionInfo not provided for CompareTo()", nameof(obj)
+            );
         }
 
-        var result = Major.CompareTo(other.Major);
-        if (result != 0)
-        {
-            return result;
-        }
-
-        result = Minor.CompareTo(other.Minor);
-        if (result != 0)
-        {
-            return result;
-        }
-
-        result = Patch.CompareTo(other.Patch);
-        if (result != 0)
-        {
-            return result;
-        }
-
-        return 0;
+        return NuGetVersion.CompareTo(other.NuGetVersion);
     }
 }

--- a/Corgibytes.Freshli.Agent.DotNet/Lib/NuGet/NuGetVersionInfo.cs
+++ b/Corgibytes.Freshli.Agent.DotNet/Lib/NuGet/NuGetVersionInfo.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -8,7 +9,7 @@ namespace Corgibytes.Freshli.Agent.DotNet.Lib.NuGet;
     *  This serves as a wrapper for the 'NuGetVersion' class in the NuGet
     *  Client SDK.
     */
-public partial class NuGetVersionInfo : IVersionInfo
+public class NuGetVersionInfo : IVersionInfo
 {
     private readonly IPackageSearchMetadata _packageSearchMetadata;
     private readonly IEnumerable<IPackageSearchMetadata> _siblingReleases;
@@ -21,7 +22,8 @@ public partial class NuGetVersionInfo : IVersionInfo
 
     private NuGetVersion NuGetVersion => _packageSearchMetadata.Identity.Version;
 
-    private static readonly Regex s_versionMetadataRegex = VersionMetadataRegex();
+    [SuppressMessage("GeneratedRegex", "SYSLIB1045:Convert to \'GeneratedRegexAttribute\'.")]
+    private static readonly Regex s_versionMetadataRegex = new("\\+[a-zA-Z0-9]+");
 
     private static string StripVersionMetadata(string version)
     {
@@ -110,7 +112,4 @@ public partial class NuGetVersionInfo : IVersionInfo
 
         return NuGetVersion.CompareTo(other.NuGetVersion);
     }
-
-    [GeneratedRegex("\\+[a-zA-Z0-9]+")]
-    private static partial Regex VersionMetadataRegex();
 }

--- a/Corgibytes.Freshli.Agent.DotNet/Lib/NuGet/Versions.cs
+++ b/Corgibytes.Freshli.Agent.DotNet/Lib/NuGet/Versions.cs
@@ -7,7 +7,7 @@ public class Versions
 {
     private static readonly ILogger<Versions> s_logger = Logging.Logger<Versions>();
 
-    public static async void UpdateManifest(string manifestFilePath, DateTimeOffset asOfDate)
+    public static async Task UpdateManifest(string manifestFilePath, DateTimeOffset asOfDate)
     {
         if (manifestFilePath.EndsWith(".config"))
         {

--- a/Corgibytes.Freshli.Agent.DotNet/Lib/NuGet/Versions.cs
+++ b/Corgibytes.Freshli.Agent.DotNet/Lib/NuGet/Versions.cs
@@ -7,7 +7,7 @@ public class Versions
 {
     private static readonly ILogger<Versions> s_logger = Logging.Logger<Versions>();
 
-    public static void UpdateManifest(string manifestFilePath, DateTimeOffset asOfDate)
+    public static async void UpdateManifest(string manifestFilePath, DateTimeOffset asOfDate)
     {
         if (manifestFilePath.EndsWith(".config"))
         {
@@ -34,7 +34,7 @@ public class Versions
 
             var shouldRetrievePreReleasePackages = versionRange.MinVersion.IsPrerelease;
             var repository = new NuGetRepository();
-            var releaseHistory = repository.GetReleaseHistory(node.Name, shouldRetrievePreReleasePackages)
+            var releaseHistory = (await repository.GetReleaseHistory(node.Name, shouldRetrievePreReleasePackages))
                 .Where(release => release.DatePublished <= asOfDate);
 
             var latestVersion = new NuGetVersion(0, 0, 0);

--- a/Corgibytes.Freshli.Agent.DotNet/Lib/ReleaseHistoryRetriever.cs
+++ b/Corgibytes.Freshli.Agent.DotNet/Lib/ReleaseHistoryRetriever.cs
@@ -7,13 +7,13 @@ public sealed class ReleaseHistoryRetriever
 {
     private readonly NuGetRepository _nuGetRepository = new();
 
-    public List<PackageReleaseData> Retrieve(string packageUrl)
+    public async Task<List<PackageReleaseData>> Retrieve(string packageUrl)
     {
         try
         {
             var purl = new PackageURL(packageUrl);
 
-            var releaseHistory = _nuGetRepository.GetReleaseHistory(purl.Name, true);
+            var releaseHistory = await _nuGetRepository.GetReleaseHistory(purl.Name, true);
             var results = releaseHistory.Select(release =>
                 new PackageReleaseData(
                     release.Version,

--- a/Corgibytes.Freshli.Agent.DotNet/appsettings.json
+++ b/Corgibytes.Freshli.Agent.DotNet/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Warning",
       "Microsoft.AspNetCore": "Warning"
     }
   }

--- a/features/gRPC/RetrieveReleaseHistory.feature
+++ b/features/gRPC/RetrieveReleaseHistory.feature
@@ -18,6 +18,11 @@ Feature: Invoking RetrieveReleaseHistory via gRPC
     Then RetrieveReleaseHistory response should contain the following versions and release dates:
     """
     0.4.0-alpha0116	2021-05-17T12:54:26.4800000Z
+    0.0.0-rc1	2021-05-17T12:54:26.480000000Z
+    0.0.0	2021-05-17T12:54:26.480000000Z
+    0.0.2	2021-05-17T12:54:26.480000000Z
+    0.0.3	2021-05-17T12:54:26.480000000Z
+    0.0.4	2021-05-17T12:54:26.480000000Z
     0.4.0-alpha0117	2021-05-17T12:55:16.0200000Z
     0.4.0-alpha0121	2021-05-17T13:06:07.4930000Z
     0.4.0-alpha0124	2021-05-17T13:12:20.7570000Z


### PR DESCRIPTION
* Ensures that async operations are waited on during gRPC calls
* Ensures that unlisted packages are included in release history (Fixes #27)
* Attempts to interpolate the release date of unlisted packages, because NuGet.org sets the publish date to 1900-01-01 whenever a package is unlisted. There does not appear to be a way to get the original release date.